### PR TITLE
fix(settings): prevent selecting portfolio accounts

### DIFF
--- a/BudgetBudget/View/AccountList.swift
+++ b/BudgetBudget/View/AccountList.swift
@@ -28,7 +28,7 @@ struct AccountList: View {
         var isSelectable = false
         
         var body: some View {
-            if account.isGroup || !isSelectable {
+            if account.isGroup || account.isPortfolio || !isSelectable {
                 AccountRowContent(account: account)
             } else {
                 Toggle(isOn: Binding(get: {


### PR DESCRIPTION
Fixes #25

As I again accidentally selected them.. This removes the checkbox to select portfolio accounts for use in the app.

### Todo
- Maybe there should be an additional visual or textual hint why one can't select them. 
- Also, sync should fail gracefully instead of plain crashing.