### PR TITLE
fix: crash related to start date setting

### DIFF
--- a/BudgetBudget/Helper/Date+Month.swift
+++ b/BudgetBudget/Helper/Date+Month.swift
@@ -55,6 +55,10 @@ public enum Month: Int, Comparable {
         lhs.rawValue < rhs.rawValue
     }
     
+    var number: Int {
+        self.rawValue
+    }
+    
     case January = 1, February, March, April, May, June, July, August, September, October, November, December
 }
 

--- a/BudgetBudget/View/ContentView.swift
+++ b/BudgetBudget/View/ContentView.swift
@@ -17,6 +17,14 @@ struct ContentView: View {
     @State var displayedMonthIDs: [String] = [Date().previousMonth().monthID, Date().monthID, Date().nextMonth().monthID/*, Date().nextMonth().nextMonth().monthID*/]
     @State var selectedDate: String
     
+    init(moneymoney: MoneyMoney, budget: Budget, selectedDate: String) {
+        self.moneymoney = moneymoney
+        self.budget = budget
+        self.selectedDate = selectedDate
+        let initialDate = budget.settings.startDate < Date().previousMonth() ? Date().previousMonth() : budget.settings.startDate
+        displayedMonthIDs = [initialDate.monthID, initialDate.nextMonth().monthID, initialDate.nextMonth(2).monthID]
+    }
+    
     var body: some View {
         BudgetView(moneymoney: moneymoney, budget: budget, displayedMonthIDs: $displayedMonthIDs)
             .toolbar {

--- a/BudgetBudget/View/MonthSelectorView.swift
+++ b/BudgetBudget/View/MonthSelectorView.swift
@@ -23,13 +23,29 @@ struct MonthSelectorView: View {
         self._displayedMonthIDs = displayedMonthIDs
     }
     
+    func monthsFor(year: Int) -> [String] {
+        if year == startDate.year {
+            return Array(MonthSelectorView.months.suffix(from: startDate.month.number-1))
+        } else {
+            return MonthSelectorView.months
+        }
+    }
+    
+    func monthNumbersFor(year: Int) -> [Int] {
+        if year == startDate.year {
+            return Array(startDate.month.number...12)
+        } else {
+            return Array(1...12)
+        }
+    }
+    
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView(.horizontal, showsIndicators: false) {
                 LazyHStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
                     ForEach(years, id: \.self) { year in
                         Section {
-                            ForEach(Array(zip(MonthSelectorView.months, Array(1...12).map({
+                            ForEach(Array(zip(monthsFor(year: year), monthNumbersFor(year: year).map({
                                 "\(year)-\(String(format: "%02d", $0))"
                             }))) , id: \.1) { month, id  in
                                 HStack(spacing: 0){

--- a/BudgetBudget/ViewModel/Budget.swift
+++ b/BudgetBudget/ViewModel/Budget.swift
@@ -46,7 +46,7 @@ class Budget: ObservableObject {
 
     struct Settings: Codable {
         var ignorePendingTransactions = true
-        var startDate = Date()
+        var startDate = Date().previousMonth()
         var startBalance = 0.0
         var currency = "EUR"
         var ignoreUncategorized = false


### PR DESCRIPTION
- When start date of budget is the current mont (default value) then the app crashed. Changed to logic so that the months shown after startup take the start date of the budget into consideration
- Fixed MonthSelectorView to not show months before the selected start date