### PR TITLE
feat: persist budget

### DIFF
--- a/BudgetBudget/ViewModel/Account.swift
+++ b/BudgetBudget/ViewModel/Account.swift
@@ -93,7 +93,7 @@ class Account: ObservableObject, Decodable, HierarchyElement, Hashable, Identifi
         children!.append(child)
     }
     
-    private var subscribers: Set<AnyCancellable> = []
+    private var cancellableBag: Set<AnyCancellable> = []
     
     required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -115,7 +115,7 @@ class Account: ObservableObject, Decodable, HierarchyElement, Hashable, Identifi
             if let self = self {
                 UserDefaults.standard.set(isSelected, forKey: "Account-\(self.id):Selected")
             }
-        }.store(in: &subscribers)
+        }.store(in: &cancellableBag)
     }
     
     // From MoneyMoney

--- a/BudgetBudget/ViewModel/CategoryBudget.swift
+++ b/BudgetBudget/ViewModel/CategoryBudget.swift
@@ -74,6 +74,16 @@ class CategoryBudget: Identifiable, ObservableObject {
                     prevCancellable?.cancel()
                 }
             }
+            
+            // Must be initiallied later so that categroies are initialized to pick up the initial value
+            DispatchQueue.main.async { [self] in
+                budgeted = UserDefaults.standard.double(forKey: "Category-\(self.category.id)-\(self.date.monthID):Budgeted")
+                $budgeted.sink { [weak self] budgeted in
+                    if let self = self {
+                        UserDefaults.standard.set(budgeted, forKey: "Category-\(self.category.id)-\(self.date.monthID):Budgeted")
+                    }
+                }.store(in: &cancellableBag)
+            }
         }
     }
 }


### PR DESCRIPTION
First crude implementation just writing to UserDefaults with unique keys. This should be improved upon in the future when switching to CloudKit storage.

Implements #28